### PR TITLE
feat(commons, ui): hide the detail of sign

### DIFF
--- a/apps/ui/src/components/WalletConnector/WalletConnectorButton.tsx
+++ b/apps/ui/src/components/WalletConnector/WalletConnectorButton.tsx
@@ -49,7 +49,7 @@ export const WalletConnectorButton: React.FC<WalletConnectorButtonProps> = (prop
 
     if (userIdentityMode === 'alwaysNervos') return truncateMiddle(signer.identityNervos(), 10);
 
-    return signer.identityOrigin();
+    return signer.identityXChain();
   }, [walletConnectStatus, disconnectedContent, signer, connectingContent, userIdentityMode]);
 
   function onClick() {

--- a/apps/ui/src/interfaces/WalletConnector/AbstractWalletSigner.ts
+++ b/apps/ui/src/interfaces/WalletConnector/AbstractWalletSigner.ts
@@ -3,38 +3,34 @@ import { TwoWaySigner } from './types';
 import { boom, unimplemented } from 'interfaces/errors';
 
 export abstract class AbstractWalletSigner<T extends NetworkBase> implements TwoWaySigner<T> {
-  constructor(private _identNervos: NervosNetwork['UserIdent'], private _identOrigin: T['UserIdent']) {}
+  constructor(private _identNervos: NervosNetwork['UserIdent'], private _identXChain: T['UserIdent']) {}
 
-  async sign(raw: T['RawTransaction']): Promise<T['SignedTransaction']> {
-    if (this._isNervosTransaction(raw)) return this._signNervos(raw);
-    if (this._isOriginTransaction(raw)) return this._signOrigin(raw);
+  async sendTransaction(raw: T['RawTransaction']): Promise<{ txId: string }> {
+    if (this._isNervosTransaction(raw)) return this._sendToNervos(raw);
+    if (this._isXChainTransaction(raw)) return this._sendToXChain(raw);
 
     boom(unimplemented);
   }
 
-  identNervos(): NervosNetwork['UserIdent'] {
+  // current signer identity on Nervos
+  identityNervos(): string {
     return this._identNervos;
   }
 
-  identOrigin(): T['UserIdent'] {
-    return this._identOrigin;
+  // current signer identity on origin network
+  identityXChain(): string {
+    return this._identXChain;
   }
 
   // sign for origin network
-  abstract _signOrigin(raw: T['RawTransaction']): T['SignedTransaction'];
+  abstract _sendToXChain(raw: T['RawTransaction']): { txId: string };
 
   // sign for nervos network
-  abstract _signNervos(raw: NervosNetwork['RawTransaction']): NervosNetwork['SignedTransaction'];
+  abstract _sendToNervos(raw: NervosNetwork['RawTransaction']): { txId: string };
 
   // check if this RawTransaction is signed for origin network
-  abstract _isOriginTransaction(raw: unknown): raw is T['RawTransaction'];
+  abstract _isXChainTransaction(raw: unknown): raw is T['RawTransaction'];
 
   // check if this RawTransaction is signed for Nervos
   abstract _isNervosTransaction(raw: unknown): raw is NervosNetwork['RawTransaction'];
-
-  // current signer identity on Nervos
-  abstract identityNervos(): string;
-
-  // current signer identity on origin network
-  abstract identityOrigin(): string;
 }

--- a/apps/ui/src/interfaces/WalletConnector/types.ts
+++ b/apps/ui/src/interfaces/WalletConnector/types.ts
@@ -7,24 +7,17 @@ export enum ConnectStatus {
 }
 
 export interface TwoWayIdentity<T extends NetworkBase> {
-  identOrigin(): T['UserIdent'];
-
-  identNervos(): NervosNetwork['UserIdent'];
-
   // get the signer identity, maybe an address of Ethereum or an account name of EOS
-  identityOrigin(): string;
+  identityXChain(): T['UserIdent'];
 
   // get the signer identity of Nervos, e.g. ckt....
-  identityNervos(): string;
+  identityNervos(): NervosNetwork['UserIdent'];
 }
 
 // Since Nervos supports multiple signatures,
 // a TwoWaySigner is able to sign Nervos transactions as well as transactions from the other network
 export interface TwoWaySigner<T extends NetworkBase = NetworkBase>
-  extends Signer<
-      T['RawTransaction'] | NervosNetwork['RawTransaction'],
-      T['SignedTransaction'] | NervosNetwork['SignedTransaction']
-    >,
+  extends Signer<T['RawTransaction'] | NervosNetwork['RawTransaction']>,
     TwoWayIdentity<T> {}
 
 export interface Wallet<T extends NetworkBase = NetworkBase> {

--- a/apps/ui/src/state/useAssetQuery.ts
+++ b/apps/ui/src/state/useAssetQuery.ts
@@ -66,7 +66,7 @@ export function useAssetQuery(): QueryObserverResult<Assets> {
       const infoToBalancePayload = ({ network, ident }: { network: string; ident: string }) => ({
         network,
         assetIdent: ident,
-        userIdent: signer.identOrigin(),
+        userIdent: signer.identityXChain(),
       });
 
       const xchainBalances = await api.getBalance(infos.xchain.map(infoToBalancePayload));

--- a/apps/ui/src/views/Bridge/BridgeOperation/useBridge.ts
+++ b/apps/ui/src/views/Bridge/BridgeOperation/useBridge.ts
@@ -46,7 +46,7 @@ export function useBridge(): BridgeState {
 
   useEffect(() => {
     if (!signer) return;
-    if (direction === BridgeDirection.In) setRecipient(signer.identOrigin());
+    if (direction === BridgeDirection.In) setRecipient(signer.identityXChain());
     if (direction === BridgeDirection.Out) setRecipient(signer.identityNervos());
   }, [signer, direction]);
 

--- a/apps/ui/src/xchain/dummy/DummyWallet.ts
+++ b/apps/ui/src/xchain/dummy/DummyWallet.ts
@@ -17,6 +17,8 @@ export class DummyWallet extends AbstractWalletConnector<NetworkTypes> {
         new DummyWalletSigner(
           'ckt1ffffffffffffffffffffffffffffffffffffffff',
           '0xffffffffffffffffffffffffffffffffffffffff',
+          'http://nervos-host-path:8114/rpc',
+          'http://dummy-host-path:1111/rpc',
         ),
       ),
     );

--- a/apps/ui/src/xchain/dummy/DummyWalletSigner.ts
+++ b/apps/ui/src/xchain/dummy/DummyWalletSigner.ts
@@ -3,27 +3,25 @@ import { AbstractWalletSigner } from 'interfaces/WalletConnector/AbstractWalletS
 import { unimplemented } from 'interfaces/errors';
 
 export class DummyWalletSigner extends AbstractWalletSigner<NetworkBase> {
+  constructor(nervosIdent: string, xchainIdent: string, private _nervosRPCURL: string, private _xchainRPCURL: string) {
+    super(nervosIdent, xchainIdent);
+  }
+
   _isNervosTransaction(raw: unknown): raw is NervosNetwork['RawTransaction'] {
     return false;
   }
 
-  _isOriginTransaction(raw: unknown): raw is NetworkBase['RawTransaction'] {
+  _isXChainTransaction(raw: unknown): raw is NetworkBase['RawTransaction'] {
     return false;
   }
 
-  _signNervos(raw: NervosNetwork['RawTransaction']): NervosNetwork['SignedTransaction'] {
+  _sendToNervos(raw: NervosNetwork['RawTransaction']): { txId: string } {
+    console.log('send transaction to Nervos: ' + this._nervosRPCURL);
     unimplemented();
   }
 
-  _signOrigin(raw: NetworkBase['RawTransaction']): NetworkBase['SignedTransaction'] {
+  _sendToXChain(raw: NetworkBase['RawTransaction']): { txId: string } {
+    console.log('send transaction to XChain: ' + this._xchainRPCURL);
     unimplemented();
-  }
-
-  identityNervos(): string {
-    return 'ckt1eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
-  }
-
-  identityOrigin(): string {
-    return '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
   }
 }

--- a/packages/commons/src/types/module.ts
+++ b/packages/commons/src/types/module.ts
@@ -2,8 +2,8 @@ import { AssetType, NetworkTypes, RequiredAsset } from './network';
 
 type Promisifiable<T> = Promise<T> | T;
 
-export interface Signer<Raw, Signed> {
-  sign: (raw: Raw) => Promisifiable<Signed>;
+export interface Signer<Raw> {
+  sendTransaction: (raw: Raw) => Promisifiable<{ txId: string }>;
 }
 
 export interface AssetModel<T extends NetworkTypes> {

--- a/packages/commons/src/types/network.ts
+++ b/packages/commons/src/types/network.ts
@@ -16,6 +16,7 @@ export type NetworkBase = {
   DerivedAssetIdent?: string;
   NativeAssetIdent?: string;
   RawTransaction?: unknown;
+  // TODO maybe deprecated the SignedTransaction
   SignedTransaction?: unknown;
 };
 


### PR DESCRIPTION
It is more intuitive to have the `Signer` only care about `sendTransaction`